### PR TITLE
Ignore failures that are retried using `pytest-rerunfailures` plugin

### DIFF
--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -27,6 +27,15 @@ def pytest_runtest_makereport(item, call):
     if os.environ.get("GITHUB_ACTIONS") != "true":
         return
 
+    try:
+        # If we have the pytest_rerunfailures plugin, and there are still
+        # retries to be run, then ignore error
+        import pytest_rerunfailures
+        if item.execution_count <= pytest_rerunfailures.get_reruns_count(item):
+            return
+    except ImportError:
+        pass
+
     if report.when == "call" and report.failed:
         # collect information to be annotated
         filesystempath, lineno, _ = report.location


### PR DESCRIPTION
This change will not annotate test failures when there retries left to run via [`pytest-rerunfailures`](https://pypi.org/project/pytest-rerunfailures/) plugin

Closes #30 