### PR TITLE
Annotate warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version:

--- a/README.md
+++ b/README.md
@@ -36,5 +36,9 @@ If your test is running in a Docker container, you have to install this plugin a
 
 If your tests are run from a subdirectory of the git repository, you have to set the `PYTEST_RUN_PATH` environment variable to the path of that directory relative to the repository root in order for GitHub to identify the files with errors correctly.
 
+### Warning annotations
+
+This plugin also supports warning annotations when used with Pytest 6.0+. To disable warning annotations, pass `--exclude-warning-annotations` to pytest.
+
 ## Screenshot
 [![Image from Gyazo](https://i.gyazo.com/b578304465dd1b755ceb0e04692a57d9.png)](https://gyazo.com/b578304465dd1b755ceb0e04692a57d9)

--- a/plugin_test.py
+++ b/plugin_test.py
@@ -126,7 +126,7 @@ def test_annotation_exclude_warnings(testdir: pytest.Testdir):
         """
     )
     testdir.monkeypatch.setenv("GITHUB_ACTIONS", "true")
-    result = testdir.runpytest_subprocess("--exclude-warnings")
+    result = testdir.runpytest_subprocess("--exclude-warning-annotations")
     assert not result.stderr.lines
 
 

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 import os
 import sys
-from collections import OrderedDict
 from typing import TYPE_CHECKING
 
 import pytest
 from _pytest._code.code import ExceptionRepr
+from packaging import version
 
 if TYPE_CHECKING:
     from _pytest.nodes import Item
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 #
 # Inspired by:
 # https://github.com/pytest-dev/pytest/blob/master/src/_pytest/terminal.py
+
+
+PYTEST_VERSION = version.parse(pytest.__version__)
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -79,25 +82,90 @@ def pytest_runtest_makereport(item: Item, call):  # noqa: ARG001
         elif isinstance(report.longrepr, str):
             longrepr += "\n\n" + report.longrepr
 
-        print(
-            _error_workflow_command(filesystempath, lineno, longrepr), file=sys.stderr
+        workflow_command = _build_workflow_command(
+            "error",
+            filesystempath,
+            lineno,
+            message=longrepr,
         )
+        print(workflow_command, file=sys.stderr)
 
 
-def _error_workflow_command(filesystempath, lineno, longrepr):
-    # Build collection of arguments. Ordering is strict for easy testing
-    details_dict = OrderedDict()
-    details_dict["file"] = filesystempath
-    if lineno is not None:
-        details_dict["line"] = lineno
+class _AnnotateWarnings:
+    def pytest_warning_recorded(self, warning_message, when, nodeid, location):  # noqa: ARG002
+        # enable only in a workflow of GitHub Actions
+        # ref: https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+        if os.environ.get("GITHUB_ACTIONS") != "true":
+            return
 
-    details = ",".join(f"{k}={v}" for k, v in details_dict.items())
+        filesystempath = warning_message.filename
+        workspace = os.environ.get("GITHUB_WORKFLOW")
 
-    if longrepr is None:
-        return f"\n::error {details}"
+        if workspace:
+            try:
+                rel_path = os.path.relpath(filesystempath, workspace)
+            except ValueError:
+                # os.path.relpath() will raise ValueError on Windows
+                # when full_path and workspace have different mount points.
+                rel_path = filesystempath
+            if not rel_path.startswith(".."):
+                filesystempath = rel_path
+        else:
+            filesystempath = os.path.relpath(filesystempath)
 
-    longrepr = _escape(longrepr)
-    return f"\n::error {details}::{longrepr}"
+        workflow_command = _build_workflow_command(
+            "warning",
+            filesystempath,
+            warning_message.lineno,
+            message=warning_message.message.args[0],
+        )
+        print(workflow_command, file=sys.stderr)
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("pytest_github_actions_annotate_failures")
+    group.addoption(
+        "--exclude-warnings",
+        action="store_true",
+        default=False,
+        help="Annotate failures in GitHub Actions.",
+    )
+
+def pytest_configure(config):
+    if not config.option.exclude_warnings:
+        config.pluginmanager.register(_AnnotateWarnings(), "annotate_warnings")
+
+
+def _build_workflow_command(
+    command_name,
+    file,
+    line,
+    end_line=None,
+    column=None,
+    end_column=None,
+    title=None,
+    message=None,
+):
+    """Build a command to annotate a workflow."""
+    result = f"::{command_name} "
+
+    entries = [
+        ("file", file),
+        ("line", line),
+        ("endLine", end_line),
+        ("col", column),
+        ("endColumn", end_column),
+        ("title", title),
+    ]
+
+    result = result + ",".join(
+        f"{k}={v}" for k, v in entries if v is not None
+    )
+
+    if message is not None:
+        result = result + "::" + _escape(message)
+
+    return result
 
 
 def _escape(s):

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -1,6 +1,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -111,7 +112,8 @@ class _AnnotateWarnings:
             if not rel_path.startswith(".."):
                 filesystempath = rel_path
         else:
-            filesystempath = os.path.relpath(filesystempath)
+            with contextlib.suppress(ValueError):
+                filesystempath = os.path.relpath(filesystempath)
 
         workflow_command = _build_workflow_command(
             "warning",

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -125,14 +125,14 @@ class _AnnotateWarnings:
 def pytest_addoption(parser):
     group = parser.getgroup("pytest_github_actions_annotate_failures")
     group.addoption(
-        "--exclude-warnings",
+        "--exclude-warning-annotations",
         action="store_true",
         default=False,
         help="Annotate failures in GitHub Actions.",
     )
 
 def pytest_configure(config):
-    if not config.option.exclude_warnings:
+    if not config.option.exclude_warning_annotations:
         config.pluginmanager.register(_AnnotateWarnings(), "annotate_warnings")
 
 


### PR DESCRIPTION
- Supported only in pytest >= 6.0.0 ([docs](https://docs.pytest.org/en/7.2.x/reference/reference.html#pytest.hookspec.pytest_warning_recorded))
- Adds an `--exclude-warning-annotations` option to exclude warning annotations

Closes #45 