### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
   - id: check-manifest
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.0.262"
   hooks:
   - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.