### PR TITLE
Drop support for pytest<6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   test:
     strategy:
@@ -37,22 +40,6 @@ jobs:
 
     - name: Test packaging
       run: tox -e pkg
-
-    - name: Run tests with PyTest 4
-      run: tox
-      if: "!startsWith(matrix.python-version, '3.1')"
-      env:
-        PLATFORM: ${{ matrix.os }}
-        PYTEST_MAJOR_VERSION: 4
-        PYTEST_PLUGINS: pytest_github_actions_annotate_failures
-
-    - name: Run tests with PyTest 5
-      run: tox
-      if: "!startsWith(matrix.python-version, '3.1')"
-      env:
-        PLATFORM: ${{ matrix.os }}
-        PYTEST_MAJOR_VERSION: 5
-        PYTEST_PLUGINS: pytest_github_actions_annotate_failures
 
     - name: Run tests with PyTest 6
       run: tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Incompatible changes
+
+- Require pytest 6+ #86 (thanks to @edgarrmondragon)
+
 ## 0.2.0 (2023-05-04)
 
 ### Incompatible changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 keywords = ["ansible", "testing", "molecule", "plugin"]
 dependencies = [
-    "pytest>=4.0.0"
+    "pytest>=6.0.0"
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39}-pytest{4,5,6,7}-{linux,windows}
-    py{310,311,312}-pytest{6,7}-{linux,windows}
+    py{37,38,39,310,311,312}-pytest{6,7}-{linux,windows}
     pkg
 
 [gh-actions]
@@ -19,16 +18,12 @@ PLATFORM =
     windows-latest: windows
 
 PYTEST_MAJOR_VERSION =
-    4: pytest4
-    5: pytest5
     6: pytest6
     7: pytest7
 
 [testenv]
 deps =
     -rrequirements.txt
-    pytest4: pytest>=4.0.0,<5.0.0
-    pytest5: pytest>=5.0.0,<6.0.0
     pytest6: pytest>=6.0.0,<7.0.0
     pytest7: pytest>=7.0.0,<7.4.0
 


### PR DESCRIPTION
Related:

* Closes #85
* Makes https://github.com/pytest-dev/pytest-github-actions-annotate-failures/pull/68 a bit simpler