### PR TITLE
chore: use dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ changelog = "https://github.com/pytest-dev/pytest-github-actions-annotate-failur
 [project.entry-points.pytest11]
 pytest_github_actions_annotate_failures = "pytest_github_actions_annotate_failures.plugin"
 
-[project.optional-dependencies]
+[dependency-groups]
+dev = [{ include-group = "test"}]
 test = ["packaging"]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ PYTEST_MAJOR_VERSION =
     8: pytest8
 
 [testenv]
-extras = test
+min_version = 4.22.0
+groups = test
 deps =
     pytest6: pytest>=6.0.0,<7.0.0
     pytest7: pytest>=7.0.0,<8.0.0


### PR DESCRIPTION
Let's use dependency-groups now before exposing a 'test' extra.
