### PR TITLE
ci: token permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
+      token: write
       attestations: write
 
     steps:


### PR DESCRIPTION
This is needed for attestations, apparently.
