### PR TITLE
Require pytest 7+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,13 +58,6 @@ jobs:
         PYTEST_MAJOR_VERSION: 7
         PYTEST_PLUGINS: pytest_github_actions_annotate_failures
 
-    - name: Run tests with PyTest 6
-      run: tox
-      if: runner.os != 'Windows' && matrix.python-version != '3.14'
-      env:
-        PYTEST_MAJOR_VERSION: 6
-        PYTEST_PLUGINS: pytest_github_actions_annotate_failures
-
   post-test:
     name: All tests passed
     if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix internal error when processing warnings #117
 - Test on Python 3.14 #115
+- Require pytest 7+ #116
 
 ## 0.3.0 (2025-01-17)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 keywords = ["ansible", "testing", "molecule", "plugin"]
 dependencies = [
-    "pytest>=6.0.0"
+    "pytest>=7.0.0"
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,313,314}-pytest{6,7,8}
+    py{38,39,310,311,312,313,314}-pytest{7,8}
 
 [gh-actions]
 python =
@@ -14,7 +14,6 @@ python =
 
 [gh-actions:env]
 PYTEST_MAJOR_VERSION =
-    6: pytest6
     7: pytest7
     8: pytest8
 
@@ -22,7 +21,6 @@ PYTEST_MAJOR_VERSION =
 min_version = 4.22.0
 groups = test
 deps =
-    pytest6: pytest>=6.0.0,<7.0.0
     pytest7: pytest>=7.0.0,<8.0.0
     pytest8: pytest>=8.0.0,<9.0.0
 


### PR DESCRIPTION
According to the [ClickPy data for pytest](https://clickpy.clickhouse.com/dashboard/pytest?min_date=2025-01-01&max_date=2025-10-07), pytest v6 represents a very small fraction of downloads, so I think it's fine to remove support for it.

It's also incompatible with Python 3.14, due to the removal of `ast.Str`.