### PR TITLE
fix(warnings): use GITHUB_WORKSPACE instead of GITHUB_WORKFLOW

### DIFF
--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -113,7 +113,7 @@ class _AnnotateWarnings:
             return
 
         filesystempath = warning_message.filename
-        workspace = os.environ.get("GITHUB_WORKFLOW")
+        workspace = os.environ.get("GITHUB_WORKSPACE")
 
         if workspace:
             try:


### PR DESCRIPTION
similar to the errors case, use `GITHUB_WORKSPACE` to determine the workspace. `GITHUB_WORKFLOW` is different, it is the name of the workflow, which is usually not a filename, unless the workflow is unnamed.

this appears to be a typo/mistake, as the error case handles it correctly. Add a similar test for the warnings case.

[GH docs](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables)