### PR TITLE
ci: Update `_extends` syntax to what Release Drafter v7 expects

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,3 @@
 ---
-# see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+# https://github.com/ansible/team-devtools — Release Drafter v7 needs repo:path for _extends
+_extends: ansible/team-devtools:/.github/release-drafter.yml


### PR DESCRIPTION
## Related

- A similar fix in an Ansible repo: https://github.com/ansible/ansible-creator/pull/577
- The Release Drafter v7 PR: https://github.com/release-drafter/release-drafter/pull/1475
- Docs: https://github.com/release-drafter/release-drafter/blob/v7.2.0/docs/configuration-loading.md#extend-other-config-files-using-_extends

