### PR TITLE
fix: Avoid emitthing duplicate GitHub Actions error annotations when running with pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,20 +47,20 @@ jobs:
         run: tox
         env:
           PYTEST_MAJOR_VERSION: 9
-          PYTEST_PLUGINS: pytest_github_actions_annotate_failures
+          PYTEST_PLUGINS: pytest_github_actions_annotate_failures,xdist
 
       - name: Run tests with PyTest 8
         run: tox
         env:
           PYTEST_MAJOR_VERSION: 8
-          PYTEST_PLUGINS: pytest_github_actions_annotate_failures
+          PYTEST_PLUGINS: pytest_github_actions_annotate_failures,xdist
 
       - name: Run tests with PyTest 7
         run: tox
         if: runner.os != 'Windows'
         env:
           PYTEST_MAJOR_VERSION: 7
-          PYTEST_PLUGINS: pytest_github_actions_annotate_failures
+          PYTEST_PLUGINS: pytest_github_actions_annotate_failures,xdist
 
   post-test:
     name: All tests passed

--- a/plugin_test.py
+++ b/plugin_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections import Counter
 
 import pytest
 from packaging import version
@@ -397,6 +398,30 @@ def test_annotation_subtest(testdir: pytest.Testdir):
             "::error file=test_annotation_subtest.py,line=7::test *custom message* *i=3*assert (3 %25 2) == 0*",
         ]
     )
+
+
+def test_with_xdist(testdir: pytest.Testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import warnings
+        import sys
+        pytest_plugins = ['pytest_github_actions_annotate_failures','xdist']
+
+        @pytest.mark.parametrize("n", range(10))
+        def test_fails(n):
+            warnings.warn(f"running {n}th")
+            assert n == 100
+        """
+    )
+    testdir.monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    result = testdir.runpytest_subprocess("-n", "10", "-s")
+    lines = Counter(
+        line for line in result.errlines if line.startswith(("::error ", "::warning "))
+    )
+
+    assert len(lines) == 20
+    assert {*lines.values()} == {1}
 
 
 # Debugging / development tip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pytest_github_actions_annotate_failures = "pytest_github_actions_annotate_failur
 
 [dependency-groups]
 dev = [{ include-group = "test" }]
-test = ["packaging"]
+test = ["packaging", "pytest-xdist"]
 
 [build-system]
 requires = [

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -26,52 +26,53 @@ if TYPE_CHECKING:
 PYTEST_VERSION = version.parse(pytest.__version__)
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_runtest_logreport(report: TestReport):
-    """Handle test reporting for all pytest versions."""
+class _AnnotateErrors:
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_logreport(self, report: TestReport):
+        """Handle test reporting for all pytest versions."""
 
-    # enable only in a workflow of GitHub Actions
-    # ref: https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-    if os.environ.get("GITHUB_ACTIONS") != "true":
-        return
+        # enable only in a workflow of GitHub Actions
+        # ref: https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+        if os.environ.get("GITHUB_ACTIONS") != "true":
+            return
 
-    # Only handle failed tests in call phase
-    if report.when == "call" and report.failed:
-        filesystempath, lineno, _ = report.location
+        # Only handle failed tests in call phase
+        if report.when == "call" and report.failed:
+            filesystempath, lineno, _ = report.location
 
-        if lineno is not None:
-            # 0-index to 1-index
-            lineno += 1
+            if lineno is not None:
+                # 0-index to 1-index
+                lineno += 1
 
-        longrepr = report.head_line or "test"
+            longrepr = report.head_line or "test"
 
-        # get the error message and line number from the actual error
-        if isinstance(report.longrepr, ExceptionRepr):
-            if report.longrepr.reprcrash is not None:
-                longrepr += "\n\n" + report.longrepr.reprcrash.message
-            tb_entries = report.longrepr.reprtraceback.reprentries
-            if tb_entries:
-                entry = tb_entries[0]
-                # Handle third-party exceptions
-                if isinstance(entry, ReprEntry) and entry.reprfileloc is not None:
-                    lineno = entry.reprfileloc.lineno
-                    filesystempath = entry.reprfileloc.path
+            # get the error message and line number from the actual error
+            if isinstance(report.longrepr, ExceptionRepr):
+                if report.longrepr.reprcrash is not None:
+                    longrepr += "\n\n" + report.longrepr.reprcrash.message
+                tb_entries = report.longrepr.reprtraceback.reprentries
+                if tb_entries:
+                    entry = tb_entries[0]
+                    # Handle third-party exceptions
+                    if isinstance(entry, ReprEntry) and entry.reprfileloc is not None:
+                        lineno = entry.reprfileloc.lineno
+                        filesystempath = entry.reprfileloc.path
 
-            elif report.longrepr.reprcrash is not None:
-                lineno = report.longrepr.reprcrash.lineno
-        elif isinstance(report.longrepr, tuple):
-            filesystempath, lineno, message = report.longrepr
-            longrepr += "\n\n" + message
-        elif isinstance(report.longrepr, str):
-            longrepr += "\n\n" + report.longrepr
+                elif report.longrepr.reprcrash is not None:
+                    lineno = report.longrepr.reprcrash.lineno
+            elif isinstance(report.longrepr, tuple):
+                filesystempath, lineno, message = report.longrepr
+                longrepr += "\n\n" + message
+            elif isinstance(report.longrepr, str):
+                longrepr += "\n\n" + report.longrepr
 
-        workflow_command = _build_workflow_command(
-            "error",
-            compute_path(filesystempath),
-            lineno,
-            message=longrepr,
-        )
-        print(workflow_command, file=sys.stderr)
+            workflow_command = _build_workflow_command(
+                "error",
+                compute_path(filesystempath),
+                lineno,
+                message=longrepr,
+            )
+            print(workflow_command, file=sys.stderr)
 
 
 def compute_path(filesystempath: str) -> str:
@@ -129,8 +130,16 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    # Plugins should not be registered for workers.
+    # On xdist workers the controller re-emits reports,
+    # so register only there to avoid duplicates.
+    if config.pluginmanager.hasplugin("xdist") and hasattr(config, "workerinput"):
+        return
+
     if not config.option.exclude_warning_annotations:
         config.pluginmanager.register(_AnnotateWarnings(), "annotate_warnings")
+
+    config.pluginmanager.register(_AnnotateErrors(), "annotate_errors")
 
 
 def _build_workflow_command(

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ PYTEST_MAJOR_VERSION =
 
 [testenv]
 min_version = 4.22.0
-groups = test
+dependency_groups = test
 deps =
     pytest7: pytest>=7.0.0,<8.0.0
     pytest8: pytest>=8.0.0,<9.0.0


### PR DESCRIPTION
With `pytest-github-actions-annotate-failures==0.4.0`, failed tests can emit duplicate `::error` workflow commands under xdist. With `0.3.0`, the annotation is emitted once.


### Reproduction

```python
# sample.py
def test():
    assert 0
```

```console
GITHUB_ACTIONS=true uvx \
--with pytest-github-actions-annotate-failures==0.4.0 \
--with pytest-xdist \
pytest sample.py -n 2
```

Output:

```
❯ GITHUB_ACTIONS=true uvx --with pytest-github-actions-annotate-failures==0.4.0 --with pytest-xdist pytest sample.py -n 2
================================================ test session starts =================================================
platform linux -- Python 3.14.2, pytest-9.1.0, pluggy-1.6.0
rootdir: /home/ishimoto/src/pytest-github-actions-annotate-failures
configfile: pyproject.toml
plugins: xdist-3.8.0, github-actions-annotate-failures-0.4.0
2 workers [1 item]
::error file=sample.py,line=5::test%0A%0Aassert 0
::error file=sample.py,line=5::test%0A%0Aassert 0
F                                                                                                              [100%]
====================================================== FAILURES ======================================================
________________________________________________________ test ________________________________________________________
[gw0] linux -- Python 3.14.2 /home/ishimoto/.cache/uv/archive-v0/8-EX62Pw4kymunE2/bin/python

    def test():
>       assert 0
E       assert 0

sample.py:5: AssertionError
============================================== short test summary info ===============================================
FAILED sample.py::test - assert 0
================================================= 1 failed in 0.16s ==================================================
```

### Fix

- Register annotation hooks only on the controller process when xdist is active. Workers skip registration because the controller re-emits their reports.
- I had to fix tox.ini: it used `groups = test`, but tox has no such key. PEP 735 dependency groups are exposed as
  `dependency_groups`, so the test deps were never installed.
