### PR TITLE
refactor: remove unused PYTEST_VERSION and packaging import

### DIFF
--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 from _pytest._code.code import ExceptionRepr, ReprEntry
-from packaging import version
 
 if TYPE_CHECKING:
     from warnings import WarningMessage
@@ -21,9 +20,6 @@ if TYPE_CHECKING:
 #
 # Inspired by:
 # https://github.com/pytest-dev/pytest/blob/master/src/_pytest/terminal.py
-
-
-PYTEST_VERSION = version.parse(pytest.__version__)
 
 
 class _AnnotateErrors:


### PR DESCRIPTION
Did a quick scan of the repo, this came up.

:robot: _AI text below_ :robot:

`PYTEST_VERSION` was computed in `plugin.py` but never referenced. The plugin handles pytest 7/8/9 differences by duck-typing on `report.longrepr` rather than branching on a version check, so the constant was dead code.

Removing it also drops the runtime `from packaging import version` import. `packaging` is not a declared dependency of this package — it was only available transitively via pytest — so the plugin no longer relies on an undeclared import. (`plugin_test.py` keeps its own `PYTEST_VERSION`, which is used to skip the subtests test on pytest < 9.)

Test suite passes unchanged.