### PR TITLE
docs: fix --exclude-warning-annotations help text

### DIFF
--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -125,7 +125,7 @@ def pytest_addoption(parser):
         "--exclude-warning-annotations",
         action="store_true",
         default=False,
-        help="Annotate failures in GitHub Actions.",
+        help="Exclude annotating warnings in GitHub Actions.",
     )
 
 


### PR DESCRIPTION
Another thing the scan noticed.

:robot: _AI text below_ :robot:

The `--exclude-warning-annotations` flag's help text read `Annotate failures in GitHub Actions.` — copy-pasted from the error-annotation feature and describing the opposite of what the flag does. The flag *disables* warning annotations.

Updated to `Exclude annotating warnings in GitHub Actions.`