### PR TITLE
chore: Use tox generative ranges

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313,314}-pytest{7,8,9}
+    py3{10-14}-pytest{7-9}
 
 [gh-actions]
 python =
@@ -17,7 +17,8 @@ PYTEST_MAJOR_VERSION =
     9: pytest9
 
 [testenv]
-min_version = 4.22.0
+requires =
+    >=4.42
 dependency_groups = test
 deps =
     pytest7: pytest>=7.0.0,<8.0.0


### PR DESCRIPTION
Also replaces `minversion` with `requires` as it's the newer recommendation.
