### PR TITLE
fix: Handle warning filename when the file and the CWD are on different Windows drives

### DIFF
--- a/plugin_test.py
+++ b/plugin_test.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import io
+import sys
+import warnings
 from collections import Counter
 
 import pytest
 from packaging import version
+
+from pytest_github_actions_annotate_failures.plugin import _AnnotateWarnings
 
 PYTEST_VERSION = version.parse(pytest.__version__)
 pytest_plugins = "pytester"
@@ -250,6 +255,42 @@ def test_annotation_warning_runpath(
             "::warning file=some_path/test_annotation_warning_runpath.py,line=6::beware",
         ]
     )
+
+
+def test_annotation_warning_cross_drive(monkeypatch: pytest.MonkeyPatch):
+    """Regression: os.path.relpath() raises ValueError on Windows when warning
+    filename and CWD are on different drive letters; must not produce INTERNALERROR."""
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.delenv("PYTEST_RUN_PATH", raising=False)
+
+    def _cross_drive_relpath(path, start=None):  # noqa: ARG001
+        msg = "path is on mount 'C:', start on mount 'D:'"
+        raise ValueError(msg)
+
+    monkeypatch.setattr("os.path.relpath", _cross_drive_relpath)
+
+    w = warnings.WarningMessage(
+        UserWarning("beware"),
+        UserWarning,
+        r"C:\some\path\test_file.py",
+        42,
+    )
+
+    captured = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", captured)
+
+    _AnnotateWarnings().pytest_warning_recorded(
+        w,
+        when="call",
+        nodeid="test_file.py::test_fn",
+        location=("test_file.py", 42, "test_fn"),
+    )
+
+    output = captured.getvalue()
+    assert "::warning" in output
+    assert "beware" in output
 
 
 def test_annotation_fail_disabled_outside_workflow(

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -107,9 +108,13 @@ class _AnnotateWarnings:
         if os.environ.get("GITHUB_ACTIONS") != "true":
             return
 
+        filesystempath = warning_message.filename
+        with contextlib.suppress(ValueError):
+            filesystempath = os.path.relpath(filesystempath)
+
         workflow_command = _build_workflow_command(
             "warning",
-            compute_path(os.path.relpath(warning_message.filename)),
+            compute_path(filesystempath),
             warning_message.lineno,
             message=str(warning_message.message),
         )


### PR DESCRIPTION
badb1c53b08428046ec602b2aab606fc50c318a4 (#138) refactored the warning path computation to call `compute_path(os.path.relpath(warning_message.filename))`, but `os.path.relpath()` raises `ValueError` on
Windows when the file and the CWD are on different drive letters.

The original code had `contextlib.suppress(ValueError)` for this case, which was lost in the refactor.

Closes #147
